### PR TITLE
Enable Comprehensive W&B Logging, Scheduler Support, and SLURM Execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,5 @@ renaissance/skimpy
 *.bbl
 *.fls
 *.fdb_latexmk
+
+.cache/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Then, you can run the image with the following command:
 
 ```bash
 mkdir -p /scratch/izar/$USER/rl-for-kinetics/output
-apptainer shell --bind "$(pwd)":/home/renaissance/work --bind "/scratch/izar/$USER/rl-for-kinetics/output:/home/renaissance/output" /scratch/izar/$USER/images/renaissance_with_ml.sif
+apptainer shell --nv --bind "$(pwd)":/home/renaissance/work --bind "/scratch/izar/$USER/rl-for-kinetics/output:/home/renaissance/output" /scratch/izar/$USER/images/renaissance_with_ml.sif
 ```
 
 If things go well, you should be able to execute the following command to check if the image is working:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generation of kinetic models using RL.
 
 ## Setting up docker container
 
-### On node provided by Ilias (recommended)
+### On node provided by Ilias 
 
 First, pull the image from the Docker registry (this should be already done, but just in case):
 
@@ -12,22 +12,41 @@ First, pull the image from the Docker registry (this should be already done, but
 sudo docker pull ludekcizinsky/renaissance_with_ml:latest
 ```
 
-Next, in your home directory, create a directory for the output. For instance:
+Next, in your home directory, create a directory for the output as well as installing the dependencies. For instance:
 
 ```bash
 mkdir -p /home/rl_team/ludek/output
+mkdir -p /home/rl_team/python_packages
 ```
 
-Make sure that the folder is writable by the user:
+Make sure that the folders are writable by the user:
 
 ```bash
 chmod -R 777 /home/rl_team/ludek/output
+chmod -R 777 /home/rl_team/python_packages
 ```
 
-Assuming you have cloned our rl repo and you are currently in it, you can start the docker container using the below command (make sure to change the output directory to the one you created earlier):
+Next, visit your w&b user setting, and copy your API key. Then add it to your `.netrc` as follows:
 
 ```bash
-sudo docker run --rm -it -v "$(pwd)":/home/renaissance/work -v "/home/rl_team/ludek/output:/home/renaissance/output" ludekcizinsky/renaissance_with_ml
+machine api.wandb.ai
+  login user
+  password <your_api_key>
+```
+
+For instance, I save mine at `/home/rl_team/ludek/.netrc`.
+
+Assuming you have cloned our rl repo and you are currently in it, you can start the docker container using the below command. Make sure to change the output directory to the one you created earlier, 
+and the python packages directory to the one you created earlier (do not change the paths within the container). Finally, double check that you also mount the `.netrc` file (I include mine in the command below):
+
+```bash
+sudo docker run --rm -it -v "$(pwd)":/home/renaissance/work -v "/home/rl_team/ludek/output:/home/renaissance/output" -v "/home/rl_team/python_packages:/home/renaissance/.local" "/home/rl_team/ludek/.netrc:/home/renaissance/.netrc" ludekcizinsky/renaissance_with_ml
+```
+
+Finally, since we have to work with python 3.6, we have to downgrade weights and biases:
+
+```bash
+pip install wandb==0.15.11
 ```
 
 If things go well, you should be able to execute the following command to check if the image is working:
@@ -36,7 +55,7 @@ If things go well, you should be able to execute the following command to check 
 python -c "import skimpy; import torch;print('Success')"
 ```
 
-### Izar 
+### Izar (if you have access, then recommended)
 
 First, pull the image from the Docker registry using apptainer (takes a couple of minutes):
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If things go well, you should be able to execute the following command to check 
 python -c "import skimpy; import torch;print('Success')"
 ```
 
-### Izar (not updated)
+### Izar 
 
 First, pull the image from the Docker registry using apptainer (takes a couple of minutes):
 
@@ -57,6 +57,8 @@ If things go well, you should be able to execute the following command to check 
 ```bash
 python -c "import skimpy; import torch;print('Success')"
 ```
+
+Finally, note that you can use GPU to speed up the training. In the config, set `device: cuda`.
 
 ### On node provided by Ilias
 

--- a/configs/lr_scheduler/constant.yaml
+++ b/configs/lr_scheduler/constant.yaml
@@ -1,0 +1,1 @@
+name: constant

--- a/configs/lr_scheduler/cosine.yaml
+++ b/configs/lr_scheduler/cosine.yaml
@@ -1,0 +1,2 @@
+name: cosine
+eta: 1e-6 # final learning rate

--- a/configs/lr_scheduler/linear_decay.yaml
+++ b/configs/lr_scheduler/linear_decay.yaml
@@ -1,0 +1,1 @@
+name: linear_decay

--- a/configs/method/default.yaml
+++ b/configs/method/default.yaml
@@ -1,5 +1,5 @@
 parameter_dim: 384
-latent_dim: 99
+latent_dim: 64
 
 
 

--- a/configs/method/refinement_ppo.yaml
+++ b/configs/method/refinement_ppo.yaml
@@ -8,4 +8,3 @@ discount_factor: 0.99
 gae_lambda: 0.98
 clip_eps: 0.2 # clipping parameter for the surrogate objective
 value_loss_weight: 0.5 # coefficient for the value function loss
-entropy_loss_weight: 0.0 # coefficient for the entropy loss

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -45,6 +45,7 @@ training:
   batch_size: 25
   num_epochs: 10
   max_grad_norm: 0.5
+  save_trained_models: true
 
 
 # Just to let Hydra know where to save the config file

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -11,7 +11,7 @@ launch_cmd: null # will be set at runtime dynamically
 logger:
   project: rl-renaissance
   entity: ludekcizinsky
-  tags: [dev]
+  tags: [baseline]
 
 
 paths:

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -3,7 +3,7 @@ defaults:
   - _self_
 
 seed: 42
-device: cpu
+device: cuda
 
 # for now ignore, we don't use wandb yet
 logger:

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -1,5 +1,6 @@
 defaults:
   - method: refinement_ppo
+  - lr_scheduler: linear_decay
   - _self_
 
 seed: 42

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -1,10 +1,11 @@
 defaults:
   - method: refinement_ppo
-  - lr_scheduler: linear_decay
+  - lr_scheduler: cosine
   - _self_
 
 seed: 42
 device: cuda
+launch_cmd: null # will be set at runtime dynamically
 
 # for now ignore, we don't use wandb yet
 logger:

--- a/helpers/env.py
+++ b/helpers/env.py
@@ -11,9 +11,9 @@ class KineticEnv:
         self.max_val = cfg.constraints.max_km
         self.reward_fn = reward_fn
         self.max_steps = cfg.training.max_steps_per_episode
-        self.device = cfg.device
+        self.device = torch.device("cpu")
 
-        self._reset_generator = torch.Generator(device=self.device)
+        self._reset_generator = torch.Generator()
         self._reset_generator.manual_seed(cfg.seed)
 
         self.state = None

--- a/helpers/env.py
+++ b/helpers/env.py
@@ -1,5 +1,6 @@
 import torch
-
+import wandb
+import numpy as np
 class KineticEnv:
     def __init__(self, cfg, reward_fn):
         """
@@ -11,6 +12,7 @@ class KineticEnv:
         self.max_val = cfg.constraints.max_km
         self.reward_fn = reward_fn
         self.max_steps = cfg.training.max_steps_per_episode
+        self.eig_cutoff = cfg.reward.eig_partition
         self.device = torch.device("cpu")
 
         self._reset_generator = torch.Generator()
@@ -18,6 +20,9 @@ class KineticEnv:
 
         self.state = None
         self.step_count = 0
+        self.env_step = 0
+        self.max_eig_values = []
+        self.was_valid_solution = []
 
     def reset(self) -> torch.Tensor:
         """Sample the same deterministic initial params on every reset."""
@@ -28,6 +33,9 @@ class KineticEnv:
             generator=self._reset_generator,
             device=self.device
         ) * (self.max_val - self.min_val) + self.min_val
+
+        self.max_eig_values = []
+        self.was_valid_solution = []
         return self.state.clone()
 
     def step(self, action: torch.Tensor):
@@ -46,11 +54,21 @@ class KineticEnv:
         )
 
         # compute black-box reward
-        r = self.reward_fn(self.state)
+        r, all_eigenvalues = self.reward_fn(self.state)
         reward = float(r) if isinstance(r, torch.Tensor) else r
+        max_eig_value = np.max(all_eigenvalues)
+        self.max_eig_values.append(max_eig_value)
+        self.was_valid_solution.append(max_eig_value < self.eig_cutoff)
+        wandb.log({
+            "episode/max_eigenvalue": max_eig_value, 
+            "episode/was_valid_solution": int(self.was_valid_solution[-1]), 
+            "env_step": self.env_step,
+        })
+
 
         # increment and check termination
         self.step_count += 1
+        self.env_step += 1
         done = (self.step_count >= self.max_steps)
 
         return self.state.clone(), reward, done

--- a/helpers/jacobian_solver.py
+++ b/helpers/jacobian_solver.py
@@ -1,0 +1,198 @@
+from pytfa.io.json import load_json_model
+from skimpy.io.yaml import load_yaml_model
+from skimpy.analysis.oracle.load_pytfa_solution import load_fluxes, \
+    load_concentrations, load_equilibrium_constants
+from skimpy.sampling.simple_parameter_sampler import SimpleParameterSampler
+from skimpy.core import *
+from skimpy.mechanisms import *
+from scipy.linalg import eigvals as eigenvalues
+from scipy.sparse.linalg import eigs as eigwhich
+from sympy import Symbol
+from skimpy.core.parameters import ParameterValues
+import pandas as pd
+import numpy as np
+from sys import argv
+import time
+
+
+
+class check_jacobian():
+
+    def __init__(self):
+
+        self.NCPU = 32
+        self.CONCENTRATION_SCALING = 1e9 # 1 mol to 1 mmol
+        self.TIME_SCALING = 1 # 1hr
+        # Parameters of the E. Coli cell
+        self.DENSITY = 1200 # g/L
+        self.GDW_GWW_RATIO = 0.25 # Assumes 70% Water
+        self.n_samples = 100
+        #print(f'FLux scaling factor: {1e-3*(self.GDW_GWW_RATIO*self.DENSITY)*self.CONCENTRATION_SCALING/self.TIME_SCALING}')
+
+    def calc_eigenvalues_recal_vmax(self):
+
+        #self.parameter_set = self.parameter_set.drop('Unnamed: 0', axis=1)
+        store_eigen = []
+        param_pop=[]
+
+        for j in range(len(self.parameter_set.index)):
+
+            param_val = self.parameter_set.loc[j]*self.CONCENTRATION_SCALING  ####
+            param_val = ParameterValues(param_val,self.kmodel)
+
+            self.kmodel.parameters = self.k_eq
+            self.kmodel.parameters = param_val   #######
+            self.parameter_sample= {v.symbol: v.value for k,v in self.kmodel.parameters.items()}
+            #Set all vmax/flux parameters to 1.
+            # TODO Generalize into Flux and Saturation parameters
+            for this_reaction in self.kmodel.reactions.values():
+                vmax_param = this_reaction.parameters.vmax_forward
+                self.parameter_sample[vmax_param.symbol] = 1
+                # Calculate the Vmax's
+
+            self.kmodel.flux_parameter_function(
+                    self.kmodel,
+                    self.parameter_sample,
+                    self.sym_conc_dict,
+                    self.flux_series
+                )
+            for c in self.conc_series.index:
+                if c in self.model_param:
+                    c_sym = self.kmodel.parameters[c].symbol
+                    self.parameter_sample[c_sym]=self.conc_series[c]
+
+            this_jacobian = self.kmodel.jacobian_fun(self.flux_series[self.kmodel.reactions],
+                                    self.conc_series[self.kmodel.reactants],self.parameter_sample)
+
+            this_real_eigenvalues = np.max(np.real(eigenvalues(this_jacobian.todense())))
+            store_eigen.append(this_real_eigenvalues)
+            this_param_sample = ParameterValues(self.parameter_sample, self.kmodel)
+            param_pop.append(this_param_sample)
+
+            del(this_param_sample)
+            del(param_val)
+            del(this_jacobian)
+            del(this_real_eigenvalues)
+
+
+        return store_eigen
+
+    def calc_eigenvalues(self):
+
+        store_eigen = []
+        store_jacobian = []
+        stable_percent = 0
+        #print('Calculating eigenvalues.....')
+        for j in range(len(self.parameter_set.index)):
+
+            #if j%100==0:
+            #   #print(f'curr. set processed : {j}')
+
+            param_val = self.parameter_set.loc[j]
+            param_val = ParameterValues(param_val,self.kmodel)
+            self.kmodel.parameters = param_val
+            self.parameter_sample = {v.symbol: v.value for k,v in self.kmodel.parameters.items()}
+
+            this_jacobian = self.kmodel.jacobian_fun(self.flux_series[self.kmodel.reactions],
+                                            self.conc_series[self.kmodel.reactants],param_val)
+            this_real_eigenvalues = sorted(np.real(eigenvalues(this_jacobian.todense())))
+
+            store_jacobian.append(this_jacobian)
+            store_eigen.append(this_real_eigenvalues)
+            is_stable = this_real_eigenvalues[-1] <= 0
+            if is_stable == True: stable_percent+=1
+
+        store_eigen = np.array(store_eigen)
+        maximal_eigen = store_eigen[:,-1]
+
+        return store_eigen, maximal_eigen, store_jacobian
+
+    def _load_models(self,met_model,exp_id, ss_idx):
+
+        path_to_tmodel = f'data/{met_model}/thermo/varma_{exp_id}'
+        path_to_kmodel = f'data/{met_model}/kinetic/kin_varma_curated.yaml'
+        path_to_samples = f'data/{met_model}/steady_state_samples/samples_{exp_id}.csv'
+
+        self.tmodel = load_json_model(path_to_tmodel)
+        self.kmodel = load_yaml_model(path_to_kmodel)
+        self.kmodel.prepare()
+        self.kmodel.compile_jacobian(sim_type = QSSA, ncpu = self.NCPU)
+
+        self.samples = pd.read_csv(path_to_samples, header=0, index_col=0).iloc[ss_idx,0:]
+
+        flux_series = load_fluxes(self.samples, self.tmodel, self.kmodel,
+                                 density=self.DENSITY,
+                                 ratio_gdw_gww=self.GDW_GWW_RATIO,
+                                 concentration_scaling=self.CONCENTRATION_SCALING,
+                                 time_scaling=self.TIME_SCALING)
+
+        conc_series = load_concentrations(self.samples, self.tmodel, self.kmodel,
+                                        concentration_scaling=self.CONCENTRATION_SCALING)
+        # Fetch equilibrium constants
+        k_eq = load_equilibrium_constants(self.samples, self.tmodel, self.kmodel,
+                                       concentration_scaling=self.CONCENTRATION_SCALING,
+                                       in_place=True)
+
+        sym_conc_dict = {Symbol(k):v for k,v in conc_series.items()}
+
+
+        sampling_parameters = SimpleParameterSampler.Parameters(n_samples=1)
+        sampler = SimpleParameterSampler(sampling_parameters)
+        sampler._compile_sampling_functions(self.kmodel, sym_conc_dict,  [])
+        model_param = self.kmodel.parameters
+
+        self.flux_series = flux_series
+        self.conc_series = conc_series
+        self.k_eq = k_eq
+        self.sym_conc_dict = sym_conc_dict
+        self.model_param = model_param
+
+        print('All models loaded')
+
+    def _load_ktmodels(self, met_model, exp_id):
+
+        path_to_tmodel = f'data/{met_model}/thermo/varma_{exp_id}'
+        path_to_kmodel = f'data/{met_model}/kinetic/kin_varma_curated.yaml'
+
+        self.tmodel = load_json_model(path_to_tmodel)
+        self.kmodel = load_yaml_model(path_to_kmodel)
+        self.kmodel.prepare()
+        self.kmodel.compile_jacobian(sim_type = QSSA, ncpu = self.NCPU)
+
+    def _load_ssprofile(self, met_model,exp_id,ss_idx):
+
+        path_to_samples = f'data/{met_model}/steady_state_samples/samples_{exp_id}.csv'
+        self.samples = pd.read_csv(path_to_samples, header=0, index_col=0).iloc[ss_idx, 0:]
+
+        flux_series = load_fluxes(self.samples, self.tmodel, self.kmodel,
+                                 density=self.DENSITY,
+                                 ratio_gdw_gww=self.GDW_GWW_RATIO,
+                                 concentration_scaling=self.CONCENTRATION_SCALING,
+                                 time_scaling=self.TIME_SCALING)
+
+        conc_series = load_concentrations(self.samples, self.tmodel, self.kmodel,
+                                        concentration_scaling=self.CONCENTRATION_SCALING)
+
+        # Fetch equilibrium constants
+        k_eq = load_equilibrium_constants(self.samples, self.tmodel, self.kmodel,
+                                       concentration_scaling=self.CONCENTRATION_SCALING,
+                                       in_place=True)
+        sym_conc_dict = {Symbol(k):v for k,v in conc_series.items()}
+
+
+        sampling_parameters = SimpleParameterSampler.Parameters(n_samples=1)
+        sampler = SimpleParameterSampler(sampling_parameters)
+        sampler._compile_sampling_functions(self.kmodel, sym_conc_dict,  [])
+        model_param = self.kmodel.parameters
+
+        self.flux_series = flux_series
+        self.conc_series = conc_series
+        self.k_eq = k_eq
+        self.sym_conc_dict = sym_conc_dict
+        self.model_param = model_param
+
+    def _prepare_parameters(self, parameters, parameter_names):
+
+        parameters = np.exp(parameters)
+        self.parameter_set = pd.DataFrame(parameters, columns = parameter_names)
+

--- a/helpers/jacobian_solver.py
+++ b/helpers/jacobian_solver.py
@@ -64,15 +64,15 @@ class check_jacobian():
             this_jacobian = self.kmodel.jacobian_fun(self.flux_series[self.kmodel.reactions],
                                     self.conc_series[self.kmodel.reactants],self.parameter_sample)
 
-            this_real_eigenvalues = np.max(np.real(eigenvalues(this_jacobian.todense())))
-            store_eigen.append(this_real_eigenvalues)
+            system_eigenvalues = np.real(eigenvalues(this_jacobian.todense()))
+            store_eigen.append(system_eigenvalues)
             this_param_sample = ParameterValues(self.parameter_sample, self.kmodel)
             param_pop.append(this_param_sample)
 
             del(this_param_sample)
             del(param_val)
             del(this_jacobian)
-            del(this_real_eigenvalues)
+            del(system_eigenvalues)
 
 
         return store_eigen

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -13,7 +13,8 @@ def get_wandb_run(cfg: DictConfig):
         dir=cfg.paths.output_dir,
     )
 
-    run.define_metric(name="ppo/*", step_metric="episode")
+    run.define_metric(name="ppo/*", step_metric="global_step")
+    run.define_metric(name="optim/*", step_metric="global_step")
     run.define_metric(name="reward/*", step_metric="episode")
 
     return run

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -3,9 +3,9 @@ from omegaconf import OmegaConf, DictConfig
 import wandb
 
 
-def get_logger(cfg: DictConfig):
+def get_wandb_run(cfg: DictConfig):
     os.makedirs(cfg.paths.output_dir, exist_ok=True)
-    logger = wandb.init(
+    run = wandb.init(
         project=cfg.logger.project,
         entity=cfg.logger.entity,
         config=OmegaConf.to_container(cfg, resolve=True),
@@ -13,4 +13,7 @@ def get_logger(cfg: DictConfig):
         dir=cfg.paths.output_dir,
     )
 
-    return logger
+    run.define_metric(name="ppo/*", step_metric="episode")
+    run.define_metric(name="reward/*", step_metric="episode")
+
+    return run

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -16,5 +16,5 @@ def get_wandb_run(cfg: DictConfig):
     run.define_metric(name="ppo/*", step_metric="global_step")
     run.define_metric(name="optim/*", step_metric="global_step")
     run.define_metric(name="reward/*", step_metric="episode")
-
+    run.define_metric(name="episode/*", step_metric="env_step")
     return run

--- a/helpers/lr_schedulers.py
+++ b/helpers/lr_schedulers.py
@@ -1,0 +1,32 @@
+from torch.optim.lr_scheduler import LinearLR, ConstantLR, CosineAnnealingLR
+
+
+def get_lr_scheduler(cfg, optimizer):
+    if cfg.lr_scheduler.name == "constant":
+        return get_constant_lr(optimizer, cfg)
+    elif cfg.lr_scheduler.name == "linear_decay":
+        return get_linear_decay(optimizer, cfg)
+    elif cfg.lr_scheduler.name == "cosine":
+        return get_cosine_annealing(optimizer, cfg)
+    else:
+        raise ValueError(f"Unknown LR scheduler: {cfg.lr_scheduler.name}")
+
+def _get_total_updates(cfg):
+    n_episodes = cfg.training.num_episodes
+    n_epochs_per_episode = cfg.training.num_epochs
+    n_updates_per_epoch = cfg.training.max_steps_per_episode / cfg.training.batch_size
+    total_updates = n_episodes * n_epochs_per_episode * n_updates_per_epoch
+    return total_updates
+
+def get_cosine_annealing(optimizer, cfg):
+    total_updates = _get_total_updates(cfg)
+    cos_annealing = CosineAnnealingLR(optimizer, T_max=total_updates, eta_min=cfg.lr_scheduler.eta)
+    return cos_annealing
+
+def get_constant_lr(optimizer, cfg):
+    return ConstantLR(optimizer, factor=1.0)
+
+def get_linear_decay(optimizer, cfg):
+    total_updates = _get_total_updates(cfg)
+    decay = LinearLR(optimizer, start_factor=1.0, end_factor=0.0, total_iters=total_updates)
+    return decay

--- a/helpers/ppo_agent.py
+++ b/helpers/ppo_agent.py
@@ -4,9 +4,10 @@ import torch.optim as optim
 
 from helpers.buffers import TrajectoryBuffer
 from helpers.env import KineticEnv
-from helpers.utils import compute_grad_norm
+from helpers.utils import compute_grad_norm, log_max_eig_dist_and_incidence_rate
 from helpers.lr_schedulers import get_lr_scheduler
 from typing import Dict
+
 
 class PolicyNetwork(nn.Module):
     def __init__(self, cfg):
@@ -78,7 +79,7 @@ class PPOAgent:
 
         self.global_step = 0
 
-    def collect_trajectory(self, env: KineticEnv):
+    def collect_trajectory(self, env: KineticEnv, episode: int):
         buf = TrajectoryBuffer()
 
         state = env.reset().to(self.device)
@@ -96,6 +97,9 @@ class PPOAgent:
             state = next_state
             if done:
                 break
+        
+        log_max_eig_dist_and_incidence_rate(env.max_eig_values, env.was_valid_solution, episode)
+
 
         trajectory = buf.to_tensors()
         buf.clear()

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -82,3 +82,23 @@ def load_pkl(name: str) -> Any:
     name = name.replace('.pkl', '')
     with open(name + '.pkl', 'rb') as f:
         return pickle.load(f)
+
+
+def compute_grad_norm(model, norm_type: float = 2.0) -> float:
+    """
+    Compute the total gradient norm over all model parameters.
+    
+    Args:
+        model (torch.nn.Module): your model
+        norm_type (float): the p‐norm to use (default: 2)
+    
+    Returns:
+        float: the total norm (as a Python float)
+    """
+    total_norm = 0.0
+    for p in model.parameters():
+        if p.grad is not None:
+            param_norm = p.grad.data.norm(norm_type)
+            total_norm += param_norm.item() ** norm_type
+    total_norm = total_norm ** (1.0 / norm_type)
+    return total_norm

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -77,11 +77,14 @@ def reward_func(chk_jcbn, names_km, eig_partition: float, gen_kinetic_params: to
     return reward
 
 
-def load_pkl(name: str) -> Any:
-    """load a pickle object"""
-    name = name.replace('.pkl', '')
-    with open(name + '.pkl', 'rb') as f:
+def load_pkl(path: str) -> Any:
+    with open(path, 'rb') as f:
         return pickle.load(f)
+
+
+def save_pkl(path: str, obj: Any):
+    with open(path, 'wb') as f:
+        pickle.dump(obj, f)
 
 
 def compute_grad_norm(model, norm_type: float = 2.0) -> float:

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -147,6 +147,32 @@ def log_max_eig_dist_and_incidence_rate(max_eig_values, was_valid_solution, epis
     plt.close(fig)
 
 
+def log_reward_distribution(rewards, episode: int):
+
+    data = np.asarray(rewards)
+
+    fig, ax = plt.subplots(figsize=(9, 6), dpi=100)
+
+    kde = gaussian_kde(data, bw_method=0.2)
+
+    x_min, x_max = data.min() - 1, data.max() + 1
+    x = np.linspace(x_min, x_max, 500)
+    y = kde(x)
+
+    ax.plot(x, y, lw=2)
+    ax.fill_between(x, y, alpha=0.3)
+    ax.set_xlabel("reward")
+    ax.set_ylabel("density")
+    ax.set_title("Smoothed density of reward")
+    fig.tight_layout()
+
+    wandb.log({
+        "reward/distribution": wandb.Image(fig), 
+        "episode": episode
+    })
+    plt.close(fig)
+
+
 def log_rl_models(
     policy_net: torch.nn.Module,
     value_net:  torch.nn.Module,

--- a/train.py
+++ b/train.py
@@ -8,7 +8,7 @@ from helpers.jacobian_solver import check_jacobian
 
 from helpers.ppo_agent import PPOAgent
 from helpers.env import KineticEnv
-from helpers.utils import reward_func, load_pkl, log_rl_models
+from helpers.utils import reward_func, load_pkl, log_rl_models, log_reward_distribution
 from helpers.logger import get_wandb_run
 
 import logging
@@ -47,8 +47,7 @@ def train(cfg: DictConfig):
         # Collect trajectory
         trajectory = ppo_agent.collect_trajectory(env, episode)
         rewards = trajectory["rewards"]
-        min_rew, max_rew, mean_rew = rewards.min(), rewards.max(), rewards.mean()
-        run.log({"reward/min_rew": min_rew, "reward/max_rew": max_rew, "reward/mean_rew": mean_rew, "episode": episode})
+        log_reward_distribution(rewards, episode)
 
         # Update PPO agent
         ppo_agent.update(trajectory)

--- a/train.py
+++ b/train.py
@@ -8,7 +8,7 @@ from helpers.jacobian_solver import check_jacobian
 
 from helpers.ppo_agent import PPOAgent
 from helpers.env import KineticEnv
-from helpers.utils import reward_func, load_pkl
+from helpers.utils import reward_func, load_pkl, log_rl_models
 from helpers.logger import get_wandb_run
 
 import logging
@@ -52,6 +52,10 @@ def train(cfg: DictConfig):
 
         # Update PPO agent
         ppo_agent.update(trajectory)
+
+    # Log models
+    if cfg.training.save_trained_models:
+        log_rl_models(ppo_agent.policy_net, ppo_agent.value_net, save_dir=cfg.paths.output_dir)
 
 if __name__ == "__main__":
     train()

--- a/train.py
+++ b/train.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import hydra

--- a/train.py
+++ b/train.py
@@ -8,6 +8,7 @@ from renaissance.kinetics.jacobian_solver import check_jacobian
 from helpers.ppo_agent import PPOAgent
 from helpers.env import KineticEnv
 from helpers.utils import reward_func, load_pkl
+from helpers.logger import get_wandb_run
 
 import logging
 
@@ -27,8 +28,8 @@ def train(cfg: DictConfig):
     chk_jcbn._load_ktmodels(cfg.paths.met_model_name, 'fdp1') # Load kinetic and thermodynamic data
     chk_jcbn._load_ssprofile(cfg.paths.met_model_name, 'fdp1', cfg.constraints.ss_idx) # Integrate steady state information
 
-    # Logger setup, todo: for now disabled, else we would get w&b run object
-    logger = None # get_logger(cfg)
+    # Logger setup
+    run = get_wandb_run(cfg)
 
     # Initialize environment
     names_km = load_pkl(cfg.paths.names_km)
@@ -37,17 +38,17 @@ def train(cfg: DictConfig):
     env.seed(cfg.seed)
 
     # Initialize PPO agent (actor and critic)
-    ppo_agent = PPOAgent(cfg, logger)
+    ppo_agent = PPOAgent(cfg, run)
    
     # Training loop
     for episode in range(cfg.training.num_episodes):
         trajectory = ppo_agent.collect_trajectory(env)
         rewards = trajectory["rewards"]
         min_rew, max_rew, mean_rew = rewards.min(), rewards.max(), rewards.mean()
-        print(f"Episode {episode+1}/{cfg.training.num_episodes} - Min reward: {min_rew:.4f}, Max reward: {max_rew:.4f}, Mean reward: {mean_rew:.4f}")
+        run.log({"reward/min_rew": min_rew, "reward/max_rew": max_rew, "reward/mean_rew": mean_rew, "episode": episode})
 
-        policy_loss, value_loss, entropy = ppo_agent.update(trajectory)
-        print(f"Episode {episode+1}/{cfg.training.num_episodes} - Policy loss: {policy_loss:.4f}, Value loss: {value_loss:.4f}, Entropy: {entropy:.4f}")
+        policy_loss, value_loss = ppo_agent.update(trajectory)
+        run.log({"ppo/policy_loss": policy_loss, "ppo/value_loss": value_loss, "episode": episode})
 
 
 if __name__ == "__main__":

--- a/train.py
+++ b/train.py
@@ -4,7 +4,7 @@ from functools import partial
 import hydra
 from omegaconf import DictConfig, OmegaConf
 
-from renaissance.kinetics.jacobian_solver import check_jacobian
+from helpers.jacobian_solver import check_jacobian
 
 from helpers.ppo_agent import PPOAgent
 from helpers.env import KineticEnv

--- a/train.slurm
+++ b/train.slurm
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH --job-name=rl_base
+#SBATCH --output=outputs/slurm/%x.%j.out       # Save output to logs with job ID
+#SBATCH --error=outputs/slurm/%x.%j.err       # Save errors to separate file
+#SBATCH --time=02:00:00                  # Max runtime (hh:mm:ss)
+#SBATCH --partition=gpu                  # Partition name (adjust if needed)
+#SBATCH --gres=gpu:1                     # Number of GPUs
+#SBATCH --cpus-per-task=20                # Adjust CPU count if needed
+#SBATCH --mem=32G                        # RAM requested
+#SBATCH --ntasks=1                       # Number of tasks
+#SBATCH --account=master
+
+USER=$1
+
+cd /home/$USER/rl-gen-of-kinetic-models/
+apptainer shell --nv --bind "$(pwd)":/home/renaissance/work --bind "/scratch/izar/$USER/rl-for-kinetics/output:/home/renaissance/output" /scratch/izar/$USER/images/renaissance_with_ml.sif
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
+nvidia-smi
+
+# Run your training script
+python train.py 'logger.tags=[dev]'

--- a/train.slurm
+++ b/train.slurm
@@ -2,7 +2,7 @@
 #SBATCH --job-name=rl_base
 #SBATCH --output=outputs/slurm/%x.%j.out       # Save output to logs with job ID
 #SBATCH --error=outputs/slurm/%x.%j.err       # Save errors to separate file
-#SBATCH --time=02:00:00                  # Max runtime (hh:mm:ss)
+#SBATCH --time=01:00:00                  # Max runtime (hh:mm:ss)
 #SBATCH --partition=gpu                  # Partition name (adjust if needed)
 #SBATCH --gres=gpu:1                     # Number of GPUs
 #SBATCH --cpus-per-task=20                # Adjust CPU count if needed
@@ -20,4 +20,5 @@ export LANG=C.UTF-8
 nvidia-smi
 
 # Run your training script
-python train.py 'logger.tags=[dev]'
+python train.py
+# python train.py 'logger.tags=[dev]'


### PR DESCRIPTION
### What does this PR do?

The overall goal of this PR is to enable logging all important metrics to w&b. You can see an example demo run along with the logged metrics split into relevant sections [here](https://wandb.ai/ludekcizinsky/rl-renaissance/workspace?nw=nwuserludekcizinsky).

Further, this PR make sure that we are:
- logging the configuration
- cmd used to launch the script
- checkpointing after the end of experiment and saving to w&b

In addition, it also adds extra features:
- constant / linear decay / cosine annealing lr schedulers
- train.slurm bash script to enable scheduling of experiments on slurm cluster
- cuda support (only possible on Izar when using apptainer)

### How was this code tested

I have tested the code on Izar on one of the dedicated interactive nodes. However, did not test it on the RL node, therefore there could be potential unexpected errors, so be aware. 